### PR TITLE
Allow connection to non-secure addresses

### DIFF
--- a/Dreadnought/Info.plist
+++ b/Dreadnought/Info.plist
@@ -2,6 +2,11 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsArbitraryLoads</key>
+		<true/>
+	</dict>
 	<key>CFBundleName</key>
 	<string>$(PRODUCT_NAME)</string>
 	<key>CFBundleIdentifier</key>


### PR DESCRIPTION
This fixes an error when connecting to remote addresses without
https, for instance Tailscale addresses.
